### PR TITLE
fix response

### DIFF
--- a/actor/response.go
+++ b/actor/response.go
@@ -10,17 +10,21 @@ type Response struct {
 
 func newResponse() *Response {
 	return &Response{
-		value: make(chan any),
+		value: make(chan any, 1),
 	}
 }
 
 func (r *Response) SetValue(value any) {
-	r.value <- value
+	select {
+	case r.value <- value:
+	default:
+	}
 }
 
 func (r *Response) Result(ctx context.Context) (any, error) {
 	select {
 	case result := <-r.value:
+		close(r.value)
 		return result, nil
 
 	case <-ctx.Done():


### PR DESCRIPTION
- Response.SetValue allows to set response value only once
- Response.Result closes the channel after reading the value